### PR TITLE
Add upper bound (730) validation for days_requested. Fixes #35

### DIFF
--- a/tests/yapcli/cli/test_link.py
+++ b/tests/yapcli/cli/test_link.py
@@ -182,7 +182,6 @@ def test_link_defaults_to_sandbox_secrets_dir(monkeypatch: pytest.MonkeyPatch) -
         lambda **kwargs: ("ins_1", "item-1", "access-1"),
     )
     monkeypatch.setattr(link, "terminate_process", lambda *args, **kwargs: None)
-    monkeypatch.setattr(link, "_get_frontend_dir", lambda: Path("."))
     result = runner.invoke(
         root_cli.app,
         [

--- a/tests/yapcli/cli/test_link.py
+++ b/tests/yapcli/cli/test_link.py
@@ -226,7 +226,6 @@ def test_link_passes_custom_days_requested(monkeypatch: pytest.MonkeyPatch) -> N
         lambda **kwargs: ("ins_1", "item-1", "access-1"),
     )
     monkeypatch.setattr(link, "terminate_process", lambda *args, **kwargs: None)
-    monkeypatch.setattr(link, "_get_frontend_dir", lambda: Path("."))
     result = runner.invoke(
         root_cli.app,
         [

--- a/tests/yapcli/test_server_link_token_days_requested.py
+++ b/tests/yapcli/test_server_link_token_days_requested.py
@@ -70,7 +70,6 @@ def test_create_link_token_ignores_env_days_requested_out_of_range(caplog) -> No
     # values outside the Plaid-specified bounds should be replaced by the default
     from yapcli.server import (
         DEFAULT_LINK_DAYS_REQUESTED,
-        MIN_LINK_DAYS_REQUESTED,
         MAX_LINK_DAYS_REQUESTED,
     )
 

--- a/yapcli/cli/link.py
+++ b/yapcli/cli/link.py
@@ -17,6 +17,7 @@ from rich.console import Console
 
 from yapcli.logging import build_log_path
 from yapcli.utils import default_log_dir, default_secrets_dir
+from yapcli.server import MIN_LINK_DAYS_REQUESTED, MAX_LINK_DAYS_REQUESTED
 
 console = Console()
 app = typer.Typer(help="Run Plaid Link locally and capture the resulting tokens.")
@@ -316,10 +317,12 @@ def link(
     days_requested: int = typer.Option(
         365,
         "--days",
-        min=1,
+        min=MIN_LINK_DAYS_REQUESTED,
+        max=MAX_LINK_DAYS_REQUESTED,
         help=(
             "Days of historical transactions requested during Link token creation "
-            "(Plaid transactions.days_requested)."
+            "(Plaid transactions.days_requested; valid range "
+            f"{MIN_LINK_DAYS_REQUESTED}-{MAX_LINK_DAYS_REQUESTED})."
         ),
         show_default=True,
     ),

--- a/yapcli/server.py
+++ b/yapcli/server.py
@@ -38,6 +38,10 @@ from plaid.api import plaid_api
 from yapcli.utils import default_secrets_dir
 
 DEFAULT_PLAID_REDIRECT_URI = ""
+
+MIN_LINK_DAYS_REQUESTED = 1
+MAX_LINK_DAYS_REQUESTED = 730
+
 DEFAULT_LINK_DAYS_REQUESTED = 365
 
 
@@ -95,10 +99,12 @@ def _resolve_link_days_requested(env: Dict[str, str]) -> int:
         )
         return DEFAULT_LINK_DAYS_REQUESTED
 
-    if days < 1:
+    if days < MIN_LINK_DAYS_REQUESTED or days > MAX_LINK_DAYS_REQUESTED:
         logger.warning(
-            "Invalid YAPCLI_DAYS_REQUESTED={!r}; must be >= 1, using default {}",
+            "Invalid YAPCLI_DAYS_REQUESTED={!r}; must be >= {} and <= {}, using default {}",
             raw,
+            MIN_LINK_DAYS_REQUESTED,
+            MAX_LINK_DAYS_REQUESTED,
             DEFAULT_LINK_DAYS_REQUESTED,
         )
         return DEFAULT_LINK_DAYS_REQUESTED


### PR DESCRIPTION
Adds upper bound validation (730) for days_requested.

- Enforces max=730 for the CLI --days option
- Adds upper bound check in _resolve_link_days_requested for environment variable usage
- Ensures values are constrained to 1–730

Fixes #35