### PR TITLE
Add secret-clearing modes to `link` CLI with interactive prompt and tests

### DIFF
--- a/tests/yapcli/cli/test_link.py
+++ b/tests/yapcli/cli/test_link.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 import pytest
+import questionary
 from typer.testing import CliRunner
 
 from yapcli.cli import link
@@ -172,6 +173,7 @@ def test_link_defaults_to_sandbox_secrets_dir(monkeypatch: pytest.MonkeyPatch) -
         seen_days["value"] = days_requested
         return None
 
+    monkeypatch.setattr(link, "_get_frontend_dir", lambda: Path("."))
     monkeypatch.setattr(link, "start_backend", fake_start_backend)
     monkeypatch.setattr(link, "start_frontend", lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -216,6 +218,7 @@ def test_link_passes_custom_days_requested(monkeypatch: pytest.MonkeyPatch) -> N
         seen_days["value"] = days_requested
         return None
 
+    monkeypatch.setattr(link, "_get_frontend_dir", lambda: Path("."))
     monkeypatch.setattr(link, "start_backend", fake_start_backend)
     monkeypatch.setattr(link, "start_frontend", lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -268,3 +271,116 @@ def test_link_rejects_invalid_products(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert result.exit_code != 0
     assert "Invalid --products" in result.output
+
+
+def test_link_clear_all_clears_only_current_environment(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = {"YAPCLI_DEFAULT_DIRS": "CWD", "PLAID_ENV": "production"}
+
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        cwd = Path.cwd()
+        (cwd / "secrets").mkdir(parents=True, exist_ok=True)
+        (cwd / "sandbox" / "secrets").mkdir(parents=True, exist_ok=True)
+        (cwd / "secrets" / "ins_prod_access_token").write_text("prod-token")
+        (cwd / "sandbox" / "secrets" / "ins_sandbox_access_token").write_text(
+            "sandbox-token"
+        )
+
+        result = runner.invoke(root_cli.app, ["link", "--clear-all"], env=env)
+
+        assert result.exit_code == 0
+        assert not (cwd / "secrets" / "ins_prod_access_token").exists()
+        assert (cwd / "sandbox" / "secrets" / "ins_sandbox_access_token").exists()
+
+
+def test_link_clear_single_institution_by_argument(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = {"YAPCLI_DEFAULT_DIRS": "CWD", "PLAID_ENV": "production"}
+
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        cwd = Path.cwd()
+        secrets = cwd / "secrets"
+        secrets.mkdir(parents=True, exist_ok=True)
+        (secrets / "ins_0000_access_token").write_text("token")
+        (secrets / "ins_0000_item_id").write_text("item")
+        (secrets / "ins_1111_access_token").write_text("other")
+
+        result = runner.invoke(
+            root_cli.app,
+            ["link", "--clear_ins", "ins_0000"],
+            env=env,
+        )
+
+        assert result.exit_code == 0
+        assert not (secrets / "ins_0000_access_token").exists()
+        assert not (secrets / "ins_0000_item_id").exists()
+        assert (secrets / "ins_1111_access_token").exists()
+
+
+def test_link_clear_interactive_uses_questionary_and_item_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = CliRunner()
+    env = {"YAPCLI_DEFAULT_DIRS": "CWD", "PLAID_ENV": "production"}
+
+    class _AskResult:
+        def ask(self):
+            return ["ins_0000"]
+
+    captured_titles: list[str] = []
+
+    def fake_checkbox(message, choices):
+        assert message == "Select institution secret(s) to clear"
+        captured_titles.extend([choice.title for choice in choices])
+        return _AskResult()
+
+    class _FakeBackend:
+        def __init__(self, access_token: str, item_id: str):
+            self.access_token = access_token
+            self.item_id = item_id
+
+        def get_item(self):
+            return {"institution": {"name": "Test Bank"}}
+
+    monkeypatch.setattr(questionary, "checkbox", fake_checkbox)
+    monkeypatch.setattr("yapcli.institutions.PlaidBackend", _FakeBackend)
+
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        cwd = Path.cwd()
+        secrets = cwd / "secrets"
+        secrets.mkdir(parents=True, exist_ok=True)
+        (secrets / "ins_0000_access_token").write_text("token")
+        (secrets / "ins_0000_item_id").write_text("item_0000")
+
+        result = runner.invoke(root_cli.app, ["link", "--clear"], env=env)
+
+        assert result.exit_code == 0
+        assert "item_id=ins_0000 - Test Bank" in captured_titles
+        assert not (secrets / "ins_0000_access_token").exists()
+        assert not (secrets / "ins_0000_item_id").exists()
+
+
+
+def test_link_clear_rejects_multiple_clear_modes() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        root_cli.app,
+        ["link", "--clear", "--clear_ins", "ins_0000"],
+    )
+
+    assert result.exit_code != 0
+    assert "Use only one of --clear, --clear_ins, or --clear-all" in result.output
+
+def test_link_clear_rejects_link_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+
+    monkeypatch.setattr(link, "start_backend", lambda *args, **kwargs: None)
+
+    result = runner.invoke(
+        root_cli.app,
+        ["link", "--clear-all", "--timeout", "1"],
+    )
+
+    assert result.exit_code != 0
+    assert "cannot be used with link" in result.output

--- a/yapcli/cli/link.py
+++ b/yapcli/cli/link.py
@@ -15,6 +15,7 @@ import typer
 from loguru import logger
 from rich.console import Console
 
+from yapcli.institutions import discover_institutions, prompt_for_institutions
 from yapcli.logging import build_log_path
 from yapcli.utils import default_log_dir, default_secrets_dir
 
@@ -278,6 +279,24 @@ def wait_for_credentials(
     raise TimeoutError
 
 
+def _clear_institution_secrets(*, secrets_dir: Path, institution_id: str) -> int:
+    removed = 0
+    for path in secrets_dir.glob(f"{institution_id}_*"):
+        if path.is_file():
+            path.unlink(missing_ok=True)
+            removed += 1
+    return removed
+
+
+def _clear_all_secrets(*, secrets_dir: Path) -> int:
+    removed = 0
+    for path in secrets_dir.glob("*"):
+        if path.is_file():
+            path.unlink(missing_ok=True)
+            removed += 1
+    return removed
+
+
 @app.command()
 def link(
     backend_port: int = typer.Option(
@@ -323,15 +342,103 @@ def link(
         ),
         show_default=True,
     ),
+    clear: bool = typer.Option(
+        False,
+        "--clear",
+        help="Clear saved secrets via interactive institution selection UI.",
+    ),
+    clear_ins: Optional[str] = typer.Option(
+        None,
+        "--clear_ins",
+        help="Clear saved secrets for one institution id (for example: --clear_ins ins_0000).",
+    ),
+    clear_all: bool = typer.Option(
+        False,
+        "--clear-all",
+        help="Clear all saved secrets.",
+    ),
 ) -> None:
     """
     Launch Plaid Link locally and wait for user to complete the flow returning an item_id and access_token.
     """
+    secrets_path = default_secrets_dir()
+
+    clear_mode_count = int(clear) + int(bool(clear_ins)) + int(clear_all)
+    if clear_mode_count > 1:
+        raise typer.BadParameter(
+            "Use only one of --clear, --clear_ins, or --clear-all"
+        )
+
+    if clear_mode_count == 1 and any(
+        [
+            backend_port != DEFAULT_BACKEND_PORT,
+            frontend_port != DEFAULT_FRONTEND_PORT,
+            timeout != 300,
+            not open_browser,
+            products is not None,
+            days_requested != 365,
+        ]
+    ):
+        raise typer.BadParameter(
+            "--clear/--clear_ins/--clear-all cannot be used with link options such as --backend-port, "
+            "--frontend-port, --timeout, --open-browser/--no-open-browser, --products, or --days"
+        )
+
+    if clear_mode_count == 1:
+        secrets_path.mkdir(parents=True, exist_ok=True)
+
+        if clear_all:
+            removed = _clear_all_secrets(secrets_dir=secrets_path)
+            console.print(
+                f"[green]Cleared[/] {removed} secret file(s) from {secrets_path}."
+            )
+            logger.info(
+                "Cleared all secrets (count={}, secrets_dir={})",
+                removed,
+                secrets_path,
+            )
+            return
+
+        selected_ids: list[str]
+        if clear_ins:
+            selected_ids = [clear_ins]
+        elif clear:
+            try:
+                discovered = discover_institutions(secrets_dir=secrets_path)
+                selected_ids = prompt_for_institutions(
+                    discovered,
+                    message="Select institution secret(s) to clear",
+                )
+            except ValueError as exc:
+                raise typer.BadParameter(str(exc)) from exc
+        else:
+            raise typer.BadParameter(
+                "Use one of --clear, --clear_ins, or --clear-all"
+            )
+
+        total_removed = 0
+        for selected_id in selected_ids:
+            removed = _clear_institution_secrets(
+                secrets_dir=secrets_path,
+                institution_id=selected_id,
+            )
+            total_removed += removed
+            console.print(
+                f"[green]Cleared[/] {removed} secret file(s) for {selected_id}."
+            )
+
+        logger.info(
+            "Cleared institution secrets (institutions={}, files_removed={}, secrets_dir={})",
+            selected_ids,
+            total_removed,
+            secrets_path,
+        )
+        return
+
     started_at = time.time()
     started_dt = dt.datetime.fromtimestamp(started_at)
     # Logging is configured once in the main Typer app callback.
 
-    secrets_path = default_secrets_dir()
     log_dir = default_log_dir()
     backend_log_path = build_log_path(
         log_dir=log_dir,

--- a/yapcli/institutions.py
+++ b/yapcli/institutions.py
@@ -62,7 +62,10 @@ def discover_institutions(*, secrets_dir: Path) -> List[DiscoveredInstitution]:
                 bank_name = None
 
         results.append(
-            DiscoveredInstitution(institution_id=identifier, bank_name=bank_name)
+            DiscoveredInstitution(
+                institution_id=identifier,
+                bank_name=bank_name,
+            )
         )
 
     if not results:
@@ -86,11 +89,10 @@ def prompt_for_institutions(
 
     choices: List[questionary.Choice] = []
     for idx, entry in enumerate(available):
-        title = (
-            f"{entry.institution_id} ({entry.bank_name})"
-            if entry.bank_name
-            else entry.institution_id
-        )
+        title_parts = [f"item_id={entry.institution_id}"]
+        if entry.bank_name:
+            title_parts.append(entry.bank_name)
+        title = " - ".join(title_parts)
         choices.append(
             questionary.Choice(
                 title=title,


### PR DESCRIPTION
### Motivation

- Provide users a way to clear saved Plaid secrets from the `link` command, either interactively, per-institution, or all at once, without launching the Link frontend/backend.
- Make interactive clearing display more useful titles (include `item_id=` and bank name) to help users identify which secrets to remove.

### Description

- Added three new `link` CLI options: `--clear`, `--clear_ins`, and `--clear-all`, with validation to ensure only one clear mode is used and that clear modes cannot be combined with `link` runtime options such as `--backend-port`, `--frontend-port`, `--timeout`, `--open-browser/--no-open-browser`, `--products`, or `--days`.
- Implemented `_clear_institution_secrets` and `_clear_all_secrets` helper functions that remove secret files from the secrets directory and report counts removed.
- Integrated existing institution discovery and interactive prompting by importing `discover_institutions` and `prompt_for_institutions` and wired interactive flow to call these when `--clear` is used; `--clear_ins` accepts a single institution id argument.
- Updated the CLI flow so clear paths execute and return early before starting frontend/backend processes, and added logging/console output for cleared files.
- Changed `prompt_for_institutions` title formatting to include `item_id=...` and the bank name separated by ` - ` for clearer display when selecting secrets to clear.
- Updated tests in `tests/yapcli/cli/test_link.py` to cover default behavior, custom days, and a number of new clearing-related tests and small test harness adjustments (importing `questionary`, monkeypatching `_get_frontend_dir` in some tests).
- Minor formatting adjustments in `yapcli/institutions.py` for consistency.

### Testing

- Ran the updated unit tests for the link CLI with `pytest tests/yapcli/cli/test_link.py`, which exercised the new `--clear`, `--clear_ins`, and `--clear-all` behaviors as well as the interactive prompt path, and all tests passed.
- Existing link-related tests (startup, days/products validation, and error paths) were executed as part of the same test file and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6afeed888328824e1c3b25dadcad)