### PR TITLE
Add `yapcli list` command to show linked institutions and accounts

### DIFF
--- a/tests/yapcli/cli/test_listing.py
+++ b/tests/yapcli/cli/test_listing.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from yapcli import cli
+from yapcli.institutions import DiscoveredInstitution
+
+
+def test_list_shows_institutions_and_accounts(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+
+    import yapcli.cli.listing as listing
+
+    monkeypatch.setenv("PLAID_SECRETS_DIR", str(tmp_path / "secrets"))
+
+    monkeypatch.setattr(
+        listing,
+        "discover_institutions",
+        lambda **kwargs: [
+            DiscoveredInstitution(institution_id="ins_1", bank_name="Bank A"),
+            DiscoveredInstitution(institution_id="ins_2", bank_name=None),
+        ],
+    )
+
+    def fake_fetch_accounts(*, institution: DiscoveredInstitution):
+        if institution.institution_id == "ins_1":
+            return [
+                {
+                    "account_id": "acc-1",
+                    "name": "Checking",
+                    "type": "depository",
+                    "subtype": "checking",
+                    "mask": "1234",
+                }
+            ]
+        return [
+            {
+                "account_id": "acc-2",
+                "official_name": "Brokerage Account",
+                "type": "investment",
+                "subtype": "brokerage",
+            }
+        ]
+
+    monkeypatch.setattr(listing, "_fetch_accounts", fake_fetch_accounts)
+
+    result = runner.invoke(cli.app, ["list"])
+
+    assert result.exit_code == 0
+    assert "ins_1 (Bank A)" in result.output
+    assert "Checking (depository/checking) account_id=acc-1 ••••1234" in result.output
+    assert "ins_2" in result.output
+    assert "Brokerage Account (investment/brokerage) account_id=acc-2" in result.output
+
+
+def test_list_handles_account_fetch_errors(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    import yapcli.cli.listing as listing
+
+    monkeypatch.setenv("PLAID_SECRETS_DIR", str(tmp_path / "secrets"))
+
+    monkeypatch.setattr(
+        listing,
+        "discover_institutions",
+        lambda **kwargs: [DiscoveredInstitution(institution_id="ins_1")],
+    )
+
+    def raise_fetch(*, institution: DiscoveredInstitution):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(listing, "_fetch_accounts", raise_fetch)
+
+    result = runner.invoke(cli.app, ["list"])
+
+    assert result.exit_code == 0
+    assert "ins_1" in result.output
+    assert "(unable to load accounts)" in result.output

--- a/yapcli/cli/listing.py
+++ b/yapcli/cli/listing.py
@@ -22,9 +22,13 @@ def _fetch_accounts(*, institution: DiscoveredInstitution) -> List[Dict[str, Any
     )
     backend = PlaidBackend(access_token=access_token, item_id=item_id)
     payload = backend.get_accounts()
-    accounts = payload.get("accounts") if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        raise ValueError("Invalid accounts payload from backend")
+    if "error" in payload:
+        raise ValueError("Error returned when fetching accounts from backend")
+    accounts = payload.get("accounts")
     if not isinstance(accounts, list):
-        return []
+        raise ValueError("Invalid accounts list in backend response")
     return [account for account in accounts if isinstance(account, dict)]
 
 

--- a/yapcli/cli/listing.py
+++ b/yapcli/cli/listing.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import typer
+from rich.console import Console
+
+from yapcli.institutions import DiscoveredInstitution, discover_institutions
+from yapcli.secrets import load_credentials
+from yapcli.server import PlaidBackend
+from yapcli.utils import default_secrets_dir
+
+console = Console()
+app = typer.Typer(help="List linked institutions and accounts.")
+
+
+def _fetch_accounts(*, institution: DiscoveredInstitution) -> List[Dict[str, Any]]:
+    secrets_dir = default_secrets_dir()
+    item_id, access_token = load_credentials(
+        institution_id=institution.institution_id,
+        secrets_dir=secrets_dir,
+    )
+    backend = PlaidBackend(access_token=access_token, item_id=item_id)
+    payload = backend.get_accounts()
+    accounts = payload.get("accounts") if isinstance(payload, dict) else None
+    if not isinstance(accounts, list):
+        return []
+    return [account for account in accounts if isinstance(account, dict)]
+
+
+@app.command("list")
+def list_linked() -> None:
+    """Show linked institutions and discovered accounts."""
+
+    secrets_dir = default_secrets_dir()
+    try:
+        institutions = discover_institutions(secrets_dir=secrets_dir)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    for institution in institutions:
+        bank_label = f" ({institution.bank_name})" if institution.bank_name else ""
+        console.print(f"[bold]{institution.institution_id}[/]{bank_label}")
+
+        try:
+            accounts = _fetch_accounts(institution=institution)
+        except Exception:
+            console.print("  [yellow](unable to load accounts)[/]")
+            continue
+
+        if not accounts:
+            console.print("  [dim](no accounts found)[/]")
+            continue
+
+        for account in accounts:
+            account_id = str(account.get("account_id") or "unknown")
+            name = str(account.get("name") or account.get("official_name") or "unnamed")
+            account_type = str(account.get("type") or "unknown")
+            subtype = str(account.get("subtype") or "unknown")
+            mask = account.get("mask")
+            suffix = f" ••••{mask}" if mask else ""
+            console.print(
+                f"  - {name} ({account_type}/{subtype}) account_id={account_id}{suffix}"
+            )

--- a/yapcli/cli/listing.py
+++ b/yapcli/cli/listing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 import typer
+from loguru import logger
 from rich.console import Console
 
 from yapcli.institutions import DiscoveredInstitution, discover_institutions
@@ -44,7 +45,8 @@ def list_linked() -> None:
 
         try:
             accounts = _fetch_accounts(institution=institution)
-        except Exception:
+        except Exception as exc:
+            logger.exception("Failed to load accounts for {}", institution.institution_id)
             console.print("  [yellow](unable to load accounts)[/]")
             continue
 

--- a/yapcli/cli/main.py
+++ b/yapcli/cli/main.py
@@ -15,6 +15,7 @@ from yapcli.cli.config import app as config_app
 from yapcli.cli.holdings import app as holdings_app
 from yapcli.cli.investment_transactions import app as investment_transactions_app
 from yapcli.cli.link import app as link_app
+from yapcli.cli.listing import app as listing_app
 from yapcli.cli.transactions import app as transactions_app
 from yapcli.logging import configure_logging, log_startup_paths
 from yapcli.utils import default_log_dir
@@ -26,6 +27,7 @@ app = typer.Typer(
     help="Utilities for interacting with Plaid programmatically.",
 )
 app.add_typer(link_app)
+app.add_typer(listing_app)
 app.add_typer(config_app, name="config")
 app.add_typer(balances_app)
 app.add_typer(holdings_app)


### PR DESCRIPTION
### Motivation
- Provide a simple CLI to inspect linked institutions and their accounts from saved secrets.
- Make it easy to confirm which institutions and accounts are available without launching the Link frontend.

### Description
- Add `yapcli.cli.listing` which implements a `list` command that discovers saved institutions via `discover_institutions`, loads credentials with `load_credentials`, and fetches accounts via `PlaidBackend.get_accounts`.
- Render each discovered institution (including bank name when available) and list its accounts with `name`, `type/subtype`, `account_id`, and masked `mask`, and show ` (no accounts found)` when none are returned.
- Gracefully handle per-institution account fetch errors by printing `(unable to load accounts)` and continuing to the next institution.
- Register the new `listing` Typer app in `yapcli.cli.main` so the command is available as `yapcli list`.
- Add `tests/yapcli/cli/test_listing.py` with unit tests that cover successful listing and error fallback behavior.

### Testing
- Ran the focused test command `PYTHONPATH=. pytest -q tests/yapcli/cli/test_listing.py tests/yapcli/cli/test_main.py` and the test suite completed successfully with `4 passed`.
- Tests exercised both rendering of institutions/accounts and the `(unable to load accounts)` error path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20e2bb3a88328973f9b2e98ff9b73)